### PR TITLE
Return a Rack::MockResponse rather than a Net::HTTP object

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -41,7 +41,7 @@ These methods are available to your test.
 
     put(url, params)
 
-    last_response() - a Net::HTTPResponse object. Use last_response.body to get the response body.
+    last_response() - a Rack::MockResponse object. Use last_response.body to get the response body.
 
     dom_response() - The response body parsed using Nokogiri::HTML().
 

--- a/lib/remote_http_testing.rb
+++ b/lib/remote_http_testing.rb
@@ -3,6 +3,7 @@ require "cgi"
 require "nokogiri"
 require "json"
 require "net/http"
+require "rack/mock"
 
 #
 # This module helps write integration tests which make HTTP requests to remote servers. Unlike Rack::Test,
@@ -98,7 +99,7 @@ module RemoteHttpTesting
     rescue Errno::ECONNREFUSED => error
       raise "Unable to connect to #{self.current_server}"
     end
-    self.last_response = response
+    self.last_response = wrap_with_mock(response)
   end
 
   def self.populate_uri_with_querystring(uri, query_string_hash)
@@ -134,5 +135,9 @@ module RemoteHttpTesting
     assert_block("There were no elements matching #{css_selector}") do
       !dom_response.css(css_selector).empty?
     end
+  end
+
+  def wrap_with_mock(response)
+    Rack::MockResponse.new(response.code, response.header.to_hash, response.body)
   end
 end

--- a/lib/remote_http_testing.rb
+++ b/lib/remote_http_testing.rb
@@ -67,9 +67,13 @@ module RemoteHttpTesting
 
   def delete(url, params = {}, request_body = nil) perform_request(url, :delete, params, request_body) end
   def get(url, params = {}, request_body = nil) perform_request(url, :get, params, request_body) end
-  def post(url, params = {}, request_body = nil) perform_request(url, :post, params, request_body) end
-  def put(url, params = {}, request_body = nil) perform_request(url, :put, params, request_body) end
-  def patch(url, params = {}, request_body = nil) perform_request(url, :patch, params, request_body) end
+
+  # POST/PUT/PATCH should params should typically be form encoded and present
+  # in the request body. This ensures the format remains consistent with
+  # Rack Test (ie - get {params}, {session info})
+  def post( url, form_params = {}, params = {}) perform_request(url, :post,  params, URI.encode_www_form(form_params)) end
+  def put(  url, form_params = {}, params = {}) perform_request(url, :put,   params, URI.encode_www_form(form_params)) end
+  def patch(url, form_params = {}, params = {}) perform_request(url, :patch, params, URI.encode_www_form(form_params)) end
 
   # Used by perform_request. This can be overridden by integration tests to append things to the request,
   # like adding a login cookie.

--- a/lib/remote_http_testing.rb
+++ b/lib/remote_http_testing.rb
@@ -71,9 +71,9 @@ module RemoteHttpTesting
   # POST/PUT/PATCH should params should typically be form encoded and present
   # in the request body. This ensures the format remains consistent with
   # Rack Test (ie - get {params}, {session info})
-  def post( url, form_params = {}, params = {}) perform_request(url, :post,  params, URI.encode_www_form(form_params)) end
-  def put(  url, form_params = {}, params = {}) perform_request(url, :put,   params, URI.encode_www_form(form_params)) end
-  def patch(url, form_params = {}, params = {}) perform_request(url, :patch, params, URI.encode_www_form(form_params)) end
+  def post( url, form_params = {}, params = {}) perform_request(url, :post,  params, CGI.unescape(form_params.to_query)) end
+  def put(  url, form_params = {}, params = {}) perform_request(url, :put,   params, CGI.unescape(form_params.to_query)) end
+  def patch(url, form_params = {}, params = {}) perform_request(url, :patch, params, CGI.unescape(form_params.to_query)) end
 
   # Used by perform_request. This can be overridden by integration tests to append things to the request,
   # like adding a login cookie.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,7 @@
+require "rubygems"
+require "rspec"
+
+path = File.expand_path(File.dirname(__FILE__) + "/../lib/")
+$LOAD_PATH.unshift(path) unless $LOAD_PATH.include?(path)
+
+require path + '/remote_http_testing'

--- a/spec/unit/remote_http_testing_spec.rb
+++ b/spec/unit/remote_http_testing_spec.rb
@@ -1,0 +1,38 @@
+require "spec_helper"
+
+class FakeClass
+  include RemoteHttpTesting
+end
+
+describe RemoteHttpTesting do
+
+  describe ".wrap_with_mock" do
+    let!(:stub_response) { stub }
+    let!(:stub_headers)  { stub }
+    let(:subject) { FakeClass.new.wrap_with_mock(stub_response) }
+
+    before do
+      stub_response.should_receive(:code).and_return("200")
+      stub_response.should_receive(:body).and_return("the body")
+      stub_response.should_receive(:header).and_return(stub_headers)
+      stub_headers.should_receive(:to_hash).and_return(:some => "header")
+    end
+
+    it "should create a new mock object" do
+      subject.class.should == Rack::MockResponse
+    end
+
+    it "should populate the body" do
+      subject.body.should == "the body"
+    end
+
+    it "should populate the headers" do
+      subject.headers[:some].should == "header"
+    end
+
+    it "should populate the status" do
+      subject.status.should == 200
+      subject.should be_successful
+    end
+  end
+end


### PR DESCRIPTION
I found it useful in my specs to be able to interchange running against a mock rack env vs via a live URL.  As such it was useful to return an object that behaved consistently.

Perhaps Rack::MockResponse should be subclassed but it's up to you if you want it.

Also added spec - `rspec spec` to run.
