### PR TITLE
added assert_block for newer versions of test:unit

### DIFF
--- a/lib/remote_http_testing.rb
+++ b/lib/remote_http_testing.rb
@@ -143,4 +143,8 @@ module RemoteHttpTesting
     end
     response
   end
+
+  def assert_block(msg = nil)
+    assert yield, msg
+  end
 end

--- a/lib/remote_http_testing/version.rb
+++ b/lib/remote_http_testing/version.rb
@@ -1,3 +1,3 @@
 module RemoteHttpTesting
-  VERSION = "0.1.4"
+  VERSION = "0.1.5"
 end


### PR DESCRIPTION
The newer versions of test:unit (or minitest) don't have `assert_block` method, so, bundled it